### PR TITLE
Calculates vbar and mbar

### DIFF
--- a/test/Beam.test.js
+++ b/test/Beam.test.js
@@ -1,4 +1,6 @@
 import assert from 'assert'
+import approx from './approx'
+
 import Beam from '../src/Beam.js'
 
 describe('beam', () => {
@@ -9,7 +11,7 @@ describe('beam', () => {
       assert.strictEqual(b._moment, null)
       assert.strictEqual(b._modulus, null)
       assert.deepStrictEqual(b._pointLoads, [])
-      assert.strictEqual(b._contLoad, null)
+      assert.strictEqual(b.contLoad(3.14), 0)
       assert.deepStrictEqual(b._anchor, ['simple', 'simple'])
       assert.strictEqual(b._isSolved, false)
     })
@@ -520,6 +522,77 @@ describe('beam', () => {
   })
 
   describe('solve', () => {
-    
+    it('should calculate vbar, mbar, thetabar, and ybar', () => {
+      let b = new Beam()
+      b.length = 10
+      let grid = b.solve(5)
+      assert.deepStrictEqual(grid.map(g => g.x), [0, 2, 4, 6, 8, 10])
+      assert.deepStrictEqual(grid.map(g => g.vbar), [0, 0, 0, 0, 0, 0])
+      assert.deepStrictEqual(grid.map(g => g.mbar), [0, 0, 0, 0, 0, 0])
+      // thetabar
+      // ybar
+
+      b = new Beam()
+      b.length = 10
+      b.contLoad = x => 10
+      grid = b.solve(5)
+      assert.deepStrictEqual(grid.map(g => g.x), [0, 2, 4, 6, 8, 10])
+      assert.deepStrictEqual(grid.map(g => g.vbar), [0, 20, 40, 60, 80, 100])
+      assert.deepStrictEqual(grid.map(g => g.mbar), [0, 20, 80, 180, 320, 500])
+      // thetabar
+      // ybar
+
+      b = new Beam()
+      b.length = 10
+      b.contLoad = x => x
+      grid = b.solve(5)
+      assert.deepStrictEqual(grid.map(g => g.x), [0, 2, 4, 6, 8, 10])
+      assert.deepStrictEqual(grid.map(g => g.vbar), [0, 2, 8, 18, 32, 50])
+      assert.deepStrictEqual(grid.map(g => g.mbar), [0, 2, 12, 38, 88, 170])
+      // thetabar
+      // ybar
+
+      b = new Beam()
+      b.length = 10
+      b.contLoad = x => x
+      grid = b.solve(500)
+      assert.deepStrictEqual(grid[500].x, 10)
+      assert.deepStrictEqual(grid[500].vbar, 50)
+      approx.equal(grid[500].mbar, 1000/6) // 166.666666...
+      // thetabar
+      // ybar
+
+      b = new Beam()
+      b.length = 100
+      b.contLoad = x => x
+      grid = b.solve(5)
+      assert.deepStrictEqual(grid.map(g => g.x), [0, 20, 40, 60, 80, 100])
+      assert.deepStrictEqual(grid.map(g => g.vbar), [0, 200, 800, 1800, 3200, 5000])
+      assert.deepStrictEqual(grid.map(g => g.mbar), [0, 2000, 12000, 38000, 88000, 170000])
+      // thetabar
+      // ybar
+
+      b = new Beam()
+      b.length = 10
+      b.addPointLoad(5, 100)
+      grid = b.solve(5)
+      assert.deepStrictEqual(grid.map(g => g.x), [0, 2, 4, 5, 5, 6, 8, 10])
+      assert.deepStrictEqual(grid.map(g => g.vbar), [0, 0, 0, 0, 100, 100, 100, 100])
+      assert.deepStrictEqual(grid.map(g => g.mbar), [0, 0, 0, 0, 0, 100, 300, 500])
+      // thetabar
+      // ybar
+
+      b = new Beam()
+      b.length = 10
+      b.addPointLoad(4, 100)
+      grid = b.solve(5)
+      assert.deepStrictEqual(grid.map(g => g.x), [0, 2, 4, 4, 6, 8, 10])
+      assert.deepStrictEqual(grid.map(g => g.vbar), [0, 0, 0, 100, 100, 100, 100])
+      assert.deepStrictEqual(grid.map(g => g.mbar), [0, 0, 0, 0, 200, 400, 600])
+      // thetabar
+      // ybar
+
+
+    })
   })
 })

--- a/test/approx.js
+++ b/test/approx.js
@@ -1,0 +1,77 @@
+const assert = require('assert')
+
+const EPSILON = 0.0001
+
+/**
+ * Test whether a value is a number
+ * @param {*} value
+ * @returns {boolean}
+ */
+function isNumber (value) {
+  return (value instanceof Number || typeof value === 'number')
+}
+
+/**
+ * Test whether two values are approximately equal. Tests whether the difference
+ * between the two numbers is smaller than a fraction of their max value.
+ * @param {Number | BigNumber | Complex | Fraction} a
+ * @param {Number | BigNumber | Complex | Fraction} b
+ * @param {Number} [epsilon]
+ */
+exports.equal = function equal (a, b, epsilon) {
+  if (epsilon === undefined) {
+    epsilon = EPSILON
+  }
+
+  if (isNumber(a) && isNumber(b)) {
+    if (a === b) {
+      // great, we're done :)
+    } else if (isNaN(a)) {
+      assert.strictEqual(a.toString(), b.toString())
+    } else if (a === 0) {
+      assert.ok(Math.abs(b) < epsilon, (a + ' ~= ' + b))
+    } else if (b === 0) {
+      assert.ok(Math.abs(a) < epsilon, (a + ' ~= ' + b))
+    } else {
+      const diff = Math.abs(a - b)
+      const max = Math.max(a, b)
+      const maxDiff = Math.abs(max * epsilon)
+      assert.ok(diff <= maxDiff, (a + ' ~= ' + b))
+    }
+  } else {
+    assert.strictEqual(a, b)
+  }
+}
+
+/**
+ * Test whether all values in two objects or arrays are approximately equal.
+ * Will deep compare all values of Arrays and Objects element wise.
+ * @param {*} a
+ * @param {*} b
+ */
+exports.deepEqual = function deepEqual (a, b) {
+  let prop, i, len
+
+  if (Array.isArray(a) && Array.isArray(b)) {
+    assert.strictEqual(a.length, b.length, a + ' ~= ' + b)
+    for (i = 0, len = a.length; i < len; i++) {
+      deepEqual(a[i], b[i])
+    }
+  } else if (a instanceof Object && b instanceof Object) {
+    for (prop in a) {
+      if (a.hasOwnProperty(prop)) {
+        assert.ok(b.hasOwnProperty(prop), a[prop] + ' ~= ' + b[prop])
+        deepEqual(a[prop], b[prop])
+      }
+    }
+
+    for (prop in b) {
+      if (b.hasOwnProperty(prop)) {
+        assert.ok(a.hasOwnProperty(prop), a[prop] + ' ~= ' + b[prop])
+        deepEqual(a[prop], b[prop])
+      }
+    }
+  } else {
+    exports.equal(a, b)
+  }
+}


### PR DESCRIPTION
Calculates `vbar` and `mbar`. The `solve()` function now takes `numGridPts` as a parameter. Tests for  several simple cases.

I left `thetabar` and `ybar` for you, @aaroncalculusman!